### PR TITLE
fix: typo

### DIFF
--- a/src/docs/events.zh-CN.md
+++ b/src/docs/events.zh-CN.md
@@ -2,7 +2,7 @@
 ### 原生事件
 通过 `onXXX` 的方式监听原生事件。
 
-```jsx
+```tsx
 import { QuarkElement, customElement } from "quarkc"
 
 @customElement({ tag: "quark-input", style })

--- a/src/docs/rendering.en-US.md
+++ b/src/docs/rendering.en-US.md
@@ -12,7 +12,7 @@ export default class Count extends QuarkElement {
 }
 ```
 
-`Qaurk` 使用 `tsx` 来作为 `UI` 表达式，因此 `render` 函数内可以包含任何 `tsx` 语法,如条件渲染、三目运算符等。你可以像写 `React` 组件一样，写 `Quark` 组件。
+`Quark` 使用 `tsx` 来作为 `UI` 表达式，因此 `render` 函数内可以包含任何 `tsx` 语法,如条件渲染、三目运算符等。你可以像写 `React` 组件一样，写 `Quark` 组件。
 
 条件渲染：
 ```tsx

--- a/src/docs/rendering.zh-CN.md
+++ b/src/docs/rendering.zh-CN.md
@@ -13,7 +13,7 @@ export default class Count extends QuarkElement {
 }
 ```
 
-`Qaurk` 使用 `tsx` 来作为 `UI` 表达式，因此 `render` 函数内可以包含任何 `tsx` 语法,如条件渲染、三目运算符等。你可以像写 `React` 组件一样，写 `Quark` 组件。
+`Quark` 使用 `tsx` 来作为 `UI` 表达式，因此 `render` 函数内可以包含任何 `tsx` 语法,如条件渲染、三目运算符等。你可以像写 `React` 组件一样，写 `Quark` 组件。
 
 条件渲染：
 ```tsx


### PR DESCRIPTION
1. `Qaurk` => `Quark`
2. Fix event docs first code block can't highlight